### PR TITLE
Make badge visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="CONTRIBUTING.md" alt="Hacktoberfest"><img src="https://badgen.net/badge/hacktoberfest/friendly/pink" /></a>
- [![Open Source](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://opensource.org/)
+ [![Open Source](https://badges.frapsoft.com/os/v3/open-source.svg?v=103)](https://opensource.org/)
 
 
 # Jackson Project Home @github


### PR DESCRIPTION
The opensource-badge is not visible in Firefox:
![grafik](https://user-images.githubusercontent.com/40789489/100650499-4eeed600-3344-11eb-96d8-7ad488069d5d.png)


Fixed it using a new version (v3):
![grafik](https://user-images.githubusercontent.com/40789489/100650514-5615e400-3344-11eb-80a8-6cc8b5bd4b22.png)
