### PR TITLE
Fix link to jaxb module

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Other fully usable modules by FasterXML team include:
 * [Base](../../../jackson-modules-base) modules:
     * [Afterburner](../../../jackson-modules-base/tree/master/afterburner): speed up databinding by 30-40% with bytecode generation to replace use of Reflection for field access, method/constructor calls
     * [Guice](../../../jackson-modules-base/tree/master/guice): extension that allows injection values from Guice injectors (and basic Guice annotations), instead of standard `@JacksonInject` (or in addition to)
-    * [JAXB Annotations](../../../jackson-modules-base/tree/master/jackson-module-jaxb-annotations): allow use of `JAXB` annotations as an alternative (in addition to or instead of) standard Jackson annotations
+    * [JAXB Annotations](../../../jackson-modules-base/tree/master/jaxb): allow use of `JAXB` annotations as an alternative (in addition to or instead of) standard Jackson annotations
     * [Mr Bean](../../../jackson-modules-base/tree/master/mrbean): "type materialization" -- let Mr Bean generate implementation classes on-the-fly (NO source code generation), to avoid monkey code
     * [OSGi](../../../jackson-modules-base/tree/master/osgi): allows injection of values from OSGi registry, via standard Jackson `@JacksonInject` annotation
     * [Paranamer](../../../jackson-modules-base/tree/master/paranamer): tiny extension for automatically figuring out creator (constructor, factory method) parameter names, to avoid having to specify `@JsonProperty`.


### PR DESCRIPTION
The README.md contained an outdated link to the jaxb-annotations module