### PR TITLE
Update MIGRATING_TO_JACKSON_3.md (MapperFeature.SORT_CREATOR_PROPERTIES_BY_DECLARATION_ORDER)

### DIFF
--- a/jackson3/MIGRATING_TO_JACKSON_3.md
+++ b/jackson3/MIGRATING_TO_JACKSON_3.md
@@ -421,6 +421,9 @@ But not all changes are equally likely to cause compatibility problems: here are
 * `MapperFeature.AUTO_DETECT_CREATORS` (and 4 related `AUTO_DETECT_xxx` variants) were removed: see "Configuring ObjectMappers" section for replacement (`JsonMapper.builder().changeDefaultVisibility(* `MapperFeature.DEFAULT_VIEW_INCLUSION` (disabled in 3.0): simple configuration change, but significant impact for `@JsonView` usage
 * `MapperFeature.SORT_PROPERTIES_ALPHABETICALLY` (enabled in 3.0): likely to change the default ordering of property serialization for POJOs (where `@JsonPropertyOrder` is not used)
     * Highly visible and may break brittle unit tests (ones that assume specific ordering)
+* `MapperFeature.SORT_CREATOR_PROPERTIES_BY_DECLARATION_ORDER` (removed in 3.0, disabled in 2.x): Effective behavior in 3.0 is the same as if this was enabled.
+  Only applies if `MapperFeature.SORT_CREATOR_PROPERTIES_FIRST` is enabled (enabled by default in 2.x & 3.0).
+  Likely to change the ordering of property serialization for POJOs (where alphabetical property ordering is used).
 * `MapperFeature.USE_GETTERS_AS_SETTERS` (disabled in 3.0): another highly non-intuitive feature; but one that may have masked actual problems (no setter or constructor for passing `Collection` / `Map` valued properties)
     * Originally included for JAXB compatibility
 ...)`)


### PR DESCRIPTION
Add bullet for removal of  MapperFeature.SORT_CREATOR_PROPERTIES_BY_DECLARATION_ORDER

We have tests that compare the serialisation output to an expected string (to help detect model changes) and our POJOs tend to use `JsonPropertyOrder(alphabetic = true)`, so the effective change from the removal of this property is an unexpected change to the serialised property order.